### PR TITLE
fix typo in si-snri

### DIFF
--- a/src/metrics/si_snri.py
+++ b/src/metrics/si_snri.py
@@ -10,8 +10,8 @@ class SISNRiMetric(SS2BaseMetric):
     def __call__(self, s1_pred: torch.Tensor, s2_pred: torch.Tensor, s1: torch.Tensor, s2: torch.Tensor, mix: torch.Tensor, **batch):
         si_snr_sep = self.forward(s1_pred=s1_pred, s2_pred=s2_pred, s1=s1, s2=s2, **batch)
 
-        si_snr_mix_s1 = self.metric(mix, s1)
-        si_snr_mix_s2 = self.metric(mix, s2)
+        si_snr_mix_s1 = self.metric(s1, mix)
+        si_snr_mix_s2 = self.metric(s2, mix)
 
         si_snr_mix = (si_snr_mix_s1 + si_snr_mix_s2) / 2
 


### PR DESCRIPTION
поменяла местами s_i и mix. теперь self.metric(s_i, mix).